### PR TITLE
Fix key error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   - id: check-yaml
   - id: check-added-large-files
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v5.6.4
+  rev: v5.9.3
   hooks:
   - id: isort
 - repo: https://github.com/psf/black

--- a/dmarc_metrics_exporter/tests/test_dmarc_metrics.py
+++ b/dmarc_metrics_exporter/tests/test_dmarc_metrics.py
@@ -32,7 +32,7 @@ def test_dmarc_metrics_upate():
 
 
 def test_dmarc_metrics_collection_update():
-    metrics_collector = DmarcMetricsCollection()
+    metrics_collector = DmarcMetricsCollection({})
     meta = Meta(
         reporter="google.com",
         from_domain="mydomain.de",


### PR DESCRIPTION
 Do not rely on defaultdict in metrics dataclasses.

The fields might be initialized with another dict that is not implementing the defaultdict behaviour (e.g. when loading persisted metrics) and this breaks the update functions.