### PR TITLE
Add dmarc-metrics-exporter executable

### DIFF
--- a/dmarc_metrics_exporter/__main__.py
+++ b/dmarc_metrics_exporter/__main__.py
@@ -2,4 +2,10 @@ import sys
 
 from .app import main
 
-main(sys.argv[1:])
+
+def run():
+    main(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ readme = "README.rst"
 repository = "https://github.com/jgosmann/dmarc-metrics-exporter/"
 version = "0.5.1"
 
+
+[tool.poetry.scripts]
+dmarc-metrics-exporter = "dmarc_metrics_exporter.__main__:run"
+
 [tool.poetry.dependencies]
 bite-parser = "^0.1.1"
 dataclasses-serialization = "^1.3.1"


### PR DESCRIPTION
Wraps the call to app.main() into a callable function that can be
wrapped into an executable, allowing installations into the PATH, which
makes it more approachable to people who aren't pythonistas.

After this change the exporter can be started using both
- python3 -m dmarc_metrics_exporter and
- dmarc-metrics-exporter