### PR TITLE
Ignore empty metrics if empty_metrics config is False

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,7 @@ The following configuration options are available:
 * ``poll_interval_seconds`` (number, default ``60``): How often to poll the IMAP server in seconds.
 * ``deduplication_max_seconds`` (number, default ``604800`` which is 7 days): How long individual report IDs will be remembered to avoid counting double delivered reports twice.
 * ``logging`` (object, default ``{}``): Logging configuration, see the "Logging configuration" section below.
+* ``empty_metrics`` (boolean, default ``true``): When set to false, Quarantine & Reject metrics aren't exposed if equals to 0
 
 Logging configuration
 ^^^^^^^^^^^^^^^^^^^^^

--- a/config/dmarc-metrics-exporter.sample.json
+++ b/config/dmarc-metrics-exporter.sample.json
@@ -29,5 +29,6 @@
                 "propagate": false
             }
         }
-    }
+    },
+    "empty_metrics": true
 }

--- a/dmarc_metrics_exporter/prometheus_exporter.py
+++ b/dmarc_metrics_exporter/prometheus_exporter.py
@@ -44,9 +44,10 @@ class PrometheusExporter:
     LABELS = ("reporter", "from_domain", "dkim_domain", "spf_domain")
     INVALID_LABELS = ("from_email",)
 
-    def __init__(self, metrics: DmarcMetricsCollection):
+    def __init__(self, metrics: DmarcMetricsCollection, empty_metrics: bool):
         self._metrics_lock = threading.Lock()
         self._metrics = metrics
+        self.empty_metrics = empty_metrics
 
     def start_server(self, listen_addr="127.0.0.1", port=9797) -> Server:
         return Server(self, listen_addr, port)
@@ -56,7 +57,7 @@ class PrometheusExporter:
         with self._metrics_lock:
             yield self._metrics
 
-    def collect(self, empty_metrics=True) -> Tuple[Any, ...]:
+    def collect(self) -> Tuple[Any, ...]:
         build_info = GaugeMetricFamily(
             "dmarc_metrics_exporter_build_info",
             "A metric with a constant '1' value labeled by version of the dmarc-metrics-exporter.",
@@ -114,10 +115,10 @@ class PrometheusExporter:
                 dmarc_total.add_metric(labels, metrics.total_count)
                 dmarc_compliant_total.add_metric(labels, metrics.dmarc_compliant_count)
                 quarantine_count = metrics.disposition_counts.get(Disposition.QUARANTINE, 0)
-                if quarantine_count > 0 or empty_metrics is True:
+                if quarantine_count > 0 or self.empty_metrics is True:
                     dmarc_quarantine_total.add_metric(labels, quarantine_count)
                 reject_count = metrics.disposition_counts.get(Disposition.REJECT, 0)
-                if quarantine_count > 0 or empty_metrics is True:
+                if quarantine_count > 0 or self.empty_metrics is True:
                     dmarc_reject_total.add_metric(labels, reject_count)
                 dmarc_spf_aligned_total.add_metric(labels, metrics.spf_aligned_count)
                 dmarc_spf_pass_total.add_metric(labels, metrics.spf_pass_count)
@@ -131,8 +132,8 @@ class PrometheusExporter:
             build_info,
             dmarc_total,
             dmarc_compliant_total,
-            dmarc_quarantine_total if quarantine_count > 0 or empty_metrics is True else None,
-            dmarc_reject_total if reject_count > 0 or empty_metrics is True else None,
+            dmarc_quarantine_total if quarantine_count > 0 or self.empty_metrics is True else None,
+            dmarc_reject_total if reject_count > 0 or self.empty_metrics is True else None,
             dmarc_spf_aligned_total,
             dmarc_spf_pass_total,
             dmarc_dkim_aligned_total,


### PR DESCRIPTION
Hey 👋🏻 

Following https://github.com/jgosmann/dmarc-metrics-exporter/issues/43, I made the following changes. I'm not a python dev and I did not tested my work yet but will do.

I'll need assistance for unit tests however.

---
This PR add the config `empty_metrics` which default to `True` to mimic current usage. When setting it to `False`, `Quarantine` & `Reject` metrics are not sent if equals to 0.

Happy to get your input !