### PR TITLE
Fix typo in dmarc_invalid_reports_total counter

### DIFF
--- a/dmarc_metrics_exporter/prometheus_exporter.py
+++ b/dmarc_metrics_exporter/prometheus_exporter.py
@@ -103,7 +103,7 @@ class PrometheusExporter:
             labels=self.LABELS,
         )
         dmarc_invalid_reports_total = CounterMetricFamily(
-            "dmaric_invalid_reports_total",
+            "dmarc_invalid_reports_total",
             "Total numebr of report emails from which no report could be parsed.",
             labels=self.INVALID_LABELS,
         )


### PR DESCRIPTION
This counter was misnamed in 4d3c7c6, but only in the name of the counter itself: the documentation and everything else are correct there.