### PR TITLE
Strip XML namespaces from DMARC reports before parsing

### DIFF
--- a/dmarc_metrics_exporter/deserialization.py
+++ b/dmarc_metrics_exporter/deserialization.py
@@ -4,6 +4,7 @@ import os.path
 from email.contentmanager import raw_data_manager
 from email.message import EmailMessage
 from typing import Callable, Generator, Mapping, Optional
+from xml.etree import ElementTree
 from zipfile import ZipFile
 
 from xsdata.formats.dataclass.context import XmlContext
@@ -72,6 +73,18 @@ class ReportExtractionError(Exception):
         return f"Failed to extract report from email by {from_email} with subject '{subject}'."
 
 
+def _strip_xml_namespaces(xml_payload: str) -> str:
+    root = ElementTree.fromstring(xml_payload)
+    for element in root.iter():
+        if isinstance(element.tag, str) and element.tag.startswith("{"):
+            element.tag = element.tag.split("}", 1)[1]
+        element.attrib = {
+            (k.split("}", 1)[1] if k.startswith("{") else k): v
+            for k, v in element.attrib.items()
+        }
+    return ElementTree.tostring(root, encoding="unicode")
+
+
 def get_aggregate_report_from_email(
     msg: EmailMessage,
 ) -> Generator[Feedback, None, None]:
@@ -85,7 +98,7 @@ def get_aggregate_report_from_email(
             content = raw_data_manager.get_content(part)
             has_found_a_report = True
             for payload in handler(part.get_filename(), content):
-                yield parser.from_string(payload, Feedback)
+                yield parser.from_string(_strip_xml_namespaces(payload), Feedback)
     if not has_found_a_report:
         raise ReportExtractionError(msg)
 

--- a/dmarc_metrics_exporter/model/tests/test_deserialization.py
+++ b/dmarc_metrics_exporter/model/tests/test_deserialization.py
@@ -1,8 +1,12 @@
+from email.mime.text import MIMEText
+
 from xsdata.formats.dataclass.context import XmlContext
 from xsdata.formats.dataclass.parsers import XmlParser
 from xsdata.formats.dataclass.parsers.config import ParserConfig
 
+from dmarc_metrics_exporter.deserialization import get_aggregate_report_from_email
 from dmarc_metrics_exporter.model.dmarc_aggregate_report import Feedback
+from dmarc_metrics_exporter.tests.sample_emails import create_email_with_attachment
 
 from .sample_data import SAMPLE_DATACLASS, create_sample_xml
 
@@ -12,3 +16,20 @@ def test_deserialization():
         context=XmlContext(), config=ParserConfig(fail_on_unknown_properties=False)
     )
     assert parser.from_string(create_sample_xml(), Feedback) == SAMPLE_DATACLASS
+
+
+def test_deserialization_with_default_namespace():
+    namespaced_xml = create_sample_xml().replace(
+        "<feedback>",
+        '<feedback xmlns="http://dmarc.org/dmarc-xml/0.1">',
+        1,
+    )
+    attachment = MIMEText(namespaced_xml, "xml")
+    attachment.add_header(
+        "Content-Disposition",
+        "attachment",
+        filename="reporter.com!localhost!1601510400!1601596799.xml",
+    )
+    msg = create_email_with_attachment(attachment)
+
+    assert list(get_aggregate_report_from_email(msg)) == [SAMPLE_DATACLASS]


### PR DESCRIPTION
First of all, thanks for the great work, this tool is very handy!

Some email providers use XML namespaces in their DMARC reports. One example of this is german email provider GMX. Their DMARC reports use `<feedback xmlns="urn:ietf:params:xml:ns:dmarc-2.0">`. The current version of this project cannot handle such reports (or any reports using an XML namespace). However, these reports do not require specific logic to process because they otherwise look identical to reports from e.g. Google, which do not use an XML namespace. The current version of this project produces an empty result on reports with a namespace.

This PR adds a test to check whether DMARC reports with an additional XML namespace are processed correctly. Before parsing any report, this commit adds a step to strip any XML namespaces from the report. With this change, DMARC reports from e.g. GMX are parsed successfully.

Generative AI was used in writing this pull request.

Please let me know if you would like me to make any changes or adjustments to this PR before merging, I am happy to improve it.